### PR TITLE
Hotfix/logger

### DIFF
--- a/.claude/skills/update-marketplace-changelog/SKILL.md
+++ b/.claude/skills/update-marketplace-changelog/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: update-marketplace-changelog
+description: Populate the JetBrains Marketplace "What's New" section in patchPluginXml by reading CHANGELOG.md and syncing the latest entries into build.gradle.kts changeNotes. Use whenever the user wants to update the marketplace release notes, sync the changelog, or says "update marketplace changelog", "populate what's new", "sync release notes".
+allowed-tools: Read, Edit, Bash, Agent
+---
+
+# Update Marketplace Changelog
+
+Sync the latest entries from `changelog/CHANGELOG.md` into the `changeNotes.set(...)` block inside `patchPluginXml` in `build.gradle.kts`.
+
+## Process
+
+### Step 1: Read the changelog
+
+Read `changelog/CHANGELOG.md` and extract the **3 most recent version entries** (everything from `# <version>` down to the next `# <version>` heading).
+
+### Step 2: Convert to HTML
+
+Convert each entry to HTML for the `changeNotes` block:
+- Version heading (`# 88.5-x.y.z [label]`) → `<h3>version — label</h3>`
+- Bullet items (`- text`) → `<li>text</li>` inside `<ul>...</ul>`
+- Inline code (backticks) → `<code>...</code>`
+
+### Step 3: Update build.gradle.kts
+
+Read `build.gradle.kts` and replace the content of `changeNotes.set("""...""".trimIndent())` inside the `patchPluginXml` block with the new HTML.
+
+If `changeNotes.set(...)` does not exist yet, add it inside `patchPluginXml { ... }` after any existing lines.
+
+### Step 4: Commit and push
+
+Use the `commit` skill with argument `and push` to stage and push the change.
+Suggested commit message type: `chore`, scope: `marketplace`.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -106,6 +106,24 @@ tasks {
 
   patchPluginXml {
     dependsOn("buildThemes")
+    changeNotes.set("""
+      <h3>88.5-1.19.1</h3>
+      <ul>
+        <li>Fix <code>repaintWindows</code>: wrap <code>repaintAllWindows()</code> inside <code>invokeLater</code> to ensure UI repaint runs on EDT</li>
+      </ul>
+      <h3>88.5-1.19.0 — 2026.1 Build Support</h3>
+      <ul>
+        <li>Lowest supported version is now 2026.1</li>
+        <li>Compiles to the 2026.1 build</li>
+        <li>Upgrade Gradle to 9.4.1, IntelliJ Platform plugin to 2.13.1, Kotlin to 2.3.0</li>
+        <li>Force <code>kotlinx-coroutines-core</code> to 1.9.0 to prevent JVM crash with IntelliJ 2026.1 agent</li>
+      </ul>
+      <h3>88.5-1.18.1</h3>
+      <ul>
+        <li>Access notification manager at runtime to comply with SDK specifications</li>
+        <li>Do not set listener on notification</li>
+      </ul>
+    """.trimIndent())
   }
 
 //  publishPlugin {

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -2,6 +2,19 @@ Changelog
 
 ---
 
+# 88.5-1.19.1-thargelion
+
+- Fix `repaintWindows`: wrap `repaintAllWindows()` inside `invokeLater` to ensure UI repaint runs on EDT
+
+# 88.5-1.19.0-thargelion [2026.1 Build Support]
+
+- Lowest supported version is now 2026.1
+- Compiles to the 2026.1 build
+- Upgrade Gradle to 9.4.1, IntelliJ Platform plugin to 2.13.1, Kotlin to 2.3.0
+- Force `kotlinx-coroutines-core` to 1.9.0 to prevent JVM crash with IntelliJ 2026.1 agent
+- Migrate deprecated `groovy.util.XmlParser/XmlNodePrinter` to `groovy.xml` package
+- Replace deprecated `toLowerCase()` with `lowercase()`
+
 # 88.5-1.18.1-thargelion
 
 - Access notification manager un runtime to comply with SDK specifications. (Use instance of service on demand instead

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # IntelliJ Platform Artifacts Repositories -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 
 pluginGroup=io.unthrottled
-pluginVersion=88.5-1.19.0-thargelion
+pluginVersion=88.5-1.19.1-thargelion
 pluginSinceBuild=253
 pluginUntilBuild=261.*
 

--- a/src/main/kotlin/io/unthrottled/doki/stickers/StickerPaneService.kt
+++ b/src/main/kotlin/io/unthrottled/doki/stickers/StickerPaneService.kt
@@ -234,8 +234,8 @@ class StickerPaneService {
 }
 
 fun repaintWindows() =
-  runSafely({
-    ApplicationManager.getApplication().invokeLater {
+  ApplicationManager.getApplication().invokeLater {
+    runSafely({
       IdeBackgroundUtil.repaintAllWindows()
-    }
-  })
+    })
+  }


### PR DESCRIPTION
This pull request updates the plugin to version `88.5-1.19.1-thargelion`, introduces a new skill for automating JetBrains Marketplace changelog updates, and includes a bug fix to ensure UI repainting occurs on the correct thread. The most important changes are grouped below.

**Plugin Update and Changelog:**

* Bump `pluginVersion` to `88.5-1.19.1-thargelion` in `gradle.properties` to reflect the new release.
* Add new changelog entries for `88.5-1.19.1-thargelion` and `88.5-1.19.0-thargelion` in `CHANGELOG.md`, including a note about fixing `repaintWindows` and updating dependencies for 2026.1 build support.

**Bug Fixes:**

* Fix `repaintWindows` in `StickerPaneService.kt` by wrapping `repaintAllWindows()` inside `invokeLater` to ensure UI updates run on the Event Dispatch Thread (EDT).

**Developer Tooling:**

* Add a new skill in `.claude/skills/update-marketplace-changelog/SKILL.md` to automate syncing the latest changelog entries into JetBrains Marketplace release notes by updating the `changeNotes` block in `build.gradle.kts`.