### PR TITLE
📦️ Sync CHANGELOG.md with 2026.2 compatibility notes

### DIFF
--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,5 +1,10 @@
 Changelog
 
+# 88.5-1.20.0-thargelion [2026.2 Build Support]
+
+- Extend compatibility range to support 2026.2 builds
+- Depend on `com.intellij.modules.jcef` (bundled) to satisfy 2026.2 platform requirements
+
 ---
 
 # 88.5-1.19.1-thargelion

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ platformVersion = 2026.1
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP
 platformPlugins =
 # Example: platformBundledPlugins = com.intellij.java
-platformBundledPlugins = XPathView
+platformBundledPlugins = XPathView, com.intellij.modules.jcef
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 9.4.1

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -15,6 +15,7 @@
         </description>
   <idea-version since-build="251"/>
   <depends>com.intellij.modules.platform</depends>
+  <depends>com.intellij.modules.jcef</depends>
   <depends optional="true" config-file="io.unthrottled.doki.theme-com.intellij.modules.lang.xml">com.intellij.modules.lang</depends>
   <depends optional="true" config-file="io.unthrottled.doki.theme-XPathView.xml">XPathView</depends>
   <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
This pull request updates the project to support IntelliJ Platform 2026.2 builds and ensures compatibility by adding a new dependency. The most important changes are as follows:

**Platform Compatibility Updates:**

* Extended the compatibility range in `CHANGELOG.md` to support 2026.2 builds.
* Updated `gradle.properties` to include `com.intellij.modules.jcef` as a bundled platform plugin, which is required for 2026.2 platform support.

**Dependency Management:**

* Added a dependency on `com.intellij.modules.jcef` in `plugin.xml` to satisfy new platform requirements.