### PR TITLE
🐛 fix: skip window repaint before app finishes loading

### DIFF
--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,5 +1,12 @@
 Changelog
 
+# 88.5-1.20.1-thargelion
+
+- Fix `repaintWindows`: skip repaint before the app finishes loading, preventing a first-install error when the editor
+  color scheme isn't ready yet
+
+---
+
 # 88.5-1.20.0-thargelion [2026.2 Build Support]
 
 - Extend compatibility range to support 2026.2 builds

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # IntelliJ Platform Artifacts Repositories -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 
 pluginGroup=io.unthrottled
-pluginVersion=88.5-1.20.0-thargelion
+pluginVersion=88.5-1.20.1-thargelion
 pluginSinceBuild=253
 pluginUntilBuild=262.*
 

--- a/src/main/kotlin/io/unthrottled/doki/stickers/StickerPaneService.kt
+++ b/src/main/kotlin/io/unthrottled/doki/stickers/StickerPaneService.kt
@@ -1,5 +1,6 @@
 package io.unthrottled.doki.stickers
 
+import com.intellij.diagnostic.LoadingState
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.ui.DialogWrapperDialog
 import com.intellij.openapi.wm.impl.IdeBackgroundUtil
@@ -235,6 +236,9 @@ class StickerPaneService {
 
 fun repaintWindows() =
   ApplicationManager.getApplication().invokeLater {
+    // ponytail: repainting before the app finishes loading crashes on the
+    // editor color scheme not being ready yet (see #362-style first-install error)
+    if (!LoadingState.APP_STARTED.isOccurred) return@invokeLater
     runSafely({
       IdeBackgroundUtil.repaintAllWindows()
     })


### PR DESCRIPTION
This pull request addresses a startup timing issue in the `StickerPaneService` to prevent crashes during application initialization. The main change ensures that window repainting only occurs after the application has fully started, avoiding errors related to uninitialized editor color schemes.

**Bug fix for startup crash:**

* Added a check using `LoadingState.APP_STARTED` in the `repaintWindows` method to ensure repainting does not occur before the application is fully loaded, preventing crashes on first install or early startup.
* Imported `LoadingState` from `com.intellij.diagnostic` to support the new startup check.